### PR TITLE
Fix version metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bollwyvl @nehaljwani
+* @bollwyvl @nehaljwani @xylar

--- a/README.md
+++ b/README.md
@@ -238,4 +238,5 @@ Feedstock Maintainers
 
 * [@bollwyvl](https://github.com/bollwyvl/)
 * [@nehaljwani](https://github.com/nehaljwani/)
+* [@xylar](https://github.com/xylar/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,3 +81,4 @@ extra:
   recipe-maintainers:
     - nehaljwani
     - bollwyvl
+    - xylar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,12 @@ source:
   sha256: 4302a8f09cd9e5ab5962f8e126d032bba98541893dd38cce6b4770969fed059d
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py < 36]
-  script: {{ PYTHON }} -m pip install . -vv
+  script:
+    - export SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}    # [unix]
+    - set SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}    # [win]
+    - {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -20,6 +23,7 @@ requirements:
     - pip
     - python
     - pyyaml >=5.2
+    - setuptools_scm
     - typing_extensions >=3.7.4.2
     - typing_inspect >=0.4.0
   run:
@@ -30,6 +34,10 @@ requirements:
     - typing_inspect >=0.4.0
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - libcst
     - libcst._nodes


### PR DESCRIPTION
Following other, similar packages, I found that this requires using
`setuptools_scm` and setting `$SETUPTOOLS_SCM_PRETEND_VERSION`

This merge also adds a `pip check` test, but that would not have
caught the version number problem.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #23 
